### PR TITLE
fix: address clippy warnings

### DIFF
--- a/src/kcc3/data_types.rs
+++ b/src/kcc3/data_types.rs
@@ -38,6 +38,7 @@ impl Player {
         }
     }
 
+    #[allow(dead_code)]
     pub fn name(&self) -> String {
         if !self.first_name.is_empty() && !self.last_name.is_empty() {
             let mut s = format!("{} {}", self.first_name, self.last_name);

--- a/src/kcc3/data_types.rs
+++ b/src/kcc3/data_types.rs
@@ -38,20 +38,6 @@ impl Player {
         }
     }
 
-    #[allow(dead_code)]
-    pub fn name(&self) -> String {
-        if !self.first_name.is_empty() && !self.last_name.is_empty() {
-            let mut s = format!("{} {}", self.first_name, self.last_name);
-            if !self.nickname.is_empty() {
-                s += &format!(" ({})", self.nickname);
-            }
-
-            s
-        } else {
-            self.nickname.clone()
-        }
-    }
-
     pub fn short_name(&self) -> String {
         if !self.nickname.is_empty() {
             self.nickname.clone()

--- a/src/kcc3/mod.rs
+++ b/src/kcc3/mod.rs
@@ -10,9 +10,9 @@ use data_types::{Chombo, Player};
 
 pub mod data_types;
 
-const API_PREFIX: &'static str = "/api/";
-const PLAYERS_ENDPOINT: &'static str = "players/";
-const CHOMBOS_ENDPOINT: &'static str = "chombos/";
+const API_PREFIX: &str = "/api/";
+const PLAYERS_ENDPOINT: &str = "players/";
+const CHOMBOS_ENDPOINT: &str = "chombos/";
 
 #[derive(Debug)]
 pub struct Kcc3ClientError {
@@ -27,7 +27,7 @@ impl Error for Kcc3ClientError {
 
 impl Kcc3ClientError {
     fn new(inner_error: reqwest::Error) -> Self {
-        return Self { inner_error };
+        Self { inner_error }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ mod chombot;
 mod kcc3;
 mod slash_commands;
 
-const AT_EVERYONE_REACTIONS: [&'static str; 2] = ["Ichiangry", "Mikiknife"];
+const AT_EVERYONE_REACTIONS: [&str; 2] = ["Ichiangry", "Mikiknife"];
 
 struct Handler {
     chombot: Chombot,

--- a/src/slash_commands/chombo.rs
+++ b/src/slash_commands/chombo.rs
@@ -5,7 +5,7 @@ use serenity::model::interactions::application_command::{
     ApplicationCommandInteraction, ApplicationCommandInteractionDataOption,
     ApplicationCommandOptionType,
 };
-use serenity::model::interactions::InteractionResponseType;
+
 use serenity::model::prelude::User;
 use serenity::utils::Colour;
 use slug::slugify;
@@ -17,12 +17,12 @@ use crate::{Chombo, Chombot, DiscordId, Player, PlayerId};
 
 const DISCORD_MESSAGE_SIZE_LIMIT: usize = 2000;
 
-const CHOMBO_COMMAND: &'static str = "chombo";
-const CHOMBO_RANKING_SUBCOMMAND: &'static str = "ranking";
-const CHOMBO_LIST_SUBCOMMAND: &'static str = "list";
-const CHOMBO_ADD_SUBCOMMAND: &'static str = "add";
-const CHOMBO_ADD_SUBCOMMAND_USER_OPTION: &'static str = "user";
-const CHOMBO_ADD_SUBCOMMAND_DESCRIPTION_OPTION: &'static str = "description";
+const CHOMBO_COMMAND: &str = "chombo";
+const CHOMBO_RANKING_SUBCOMMAND: &str = "ranking";
+const CHOMBO_LIST_SUBCOMMAND: &str = "list";
+const CHOMBO_ADD_SUBCOMMAND: &str = "add";
+const CHOMBO_ADD_SUBCOMMAND_USER_OPTION: &str = "user";
+const CHOMBO_ADD_SUBCOMMAND_DESCRIPTION_OPTION: &str = "description";
 
 pub struct ChomboCommand;
 
@@ -213,15 +213,15 @@ impl SlashCommand for ChomboCommand {
 
         match subcommand.name.as_str() {
             CHOMBO_RANKING_SUBCOMMAND => {
-                self.handle_ranking_subcommand(ctx, &command, subcommand, chombot)
+                self.handle_ranking_subcommand(ctx, command, subcommand, chombot)
                     .await?
             }
             CHOMBO_LIST_SUBCOMMAND => {
-                self.handle_list_subcommand(ctx, &command, subcommand, chombot)
+                self.handle_list_subcommand(ctx, command, subcommand, chombot)
                     .await?
             }
             CHOMBO_ADD_SUBCOMMAND => {
-                self.handle_add_subcommand(ctx, &command, subcommand, chombot)
+                self.handle_add_subcommand(ctx, command, subcommand, chombot)
                     .await?
             }
             &_ => {}

--- a/src/slash_commands/hand.rs
+++ b/src/slash_commands/hand.rs
@@ -12,13 +12,13 @@ use crate::slash_commands::utils::get_string_option;
 use crate::slash_commands::{SlashCommand, SlashCommandResult};
 use crate::Chombot;
 
-const HAND_COMMAND: &'static str = "hand";
-const HAND_OPTION: &'static str = "hand";
-const TILE_STYLE_OPTION: &'static str = "tileset";
+const HAND_COMMAND: &str = "hand";
+const HAND_OPTION: &str = "hand";
+const TILE_STYLE_OPTION: &str = "tileset";
 
-const YELLOW_TILE_SET: &'static str = "yellow";
-const RED_TILE_SET: &'static str = "red";
-const BLACK_TILE_SET: &'static str = "black";
+const YELLOW_TILE_SET: &str = "yellow";
+const RED_TILE_SET: &str = "red";
+const BLACK_TILE_SET: &str = "black";
 const DEFAULT_TILE_SET: &str = YELLOW_TILE_SET;
 
 pub struct HandCommand;

--- a/src/slash_commands/mod.rs
+++ b/src/slash_commands/mod.rs
@@ -51,10 +51,11 @@ impl SlashCommands {
         }
     }
 
-    fn get_command(&self, command_name: &str) -> Option<&Box<dyn SlashCommand>> {
+    fn get_command(&self, command_name: &str) -> Option<&dyn SlashCommand> {
         self.commands
             .iter()
             .find(|command| command.get_name() == command_name)
+            .map(Box::as_ref)
     }
 
     async fn set_error_message(
@@ -72,13 +73,13 @@ impl SlashCommands {
     }
 
     async fn handle_slash_command(
-        slash_command: &Box<dyn SlashCommand>,
+        slash_command: &dyn SlashCommand,
         ctx: &Context,
         command: &ApplicationCommandInteraction,
         chombot: &Chombot,
         requested_command_name: &str,
     ) -> Result<(), String> {
-        if let Err(e) = slash_command.handle(&ctx, &command, chombot).await {
+        if let Err(e) = slash_command.handle(ctx, command, chombot).await {
             println!(
                 "Handler error for command {}: {:?}",
                 requested_command_name, e

--- a/src/slash_commands/utils.rs
+++ b/src/slash_commands/utils.rs
@@ -5,10 +5,7 @@ use serenity::model::interactions::application_command::{
 };
 use serenity::model::user::User;
 
-fn get_option<'a>(
-    options: &'a [DataOption],
-    option_name: &'static str,
-) -> Option<&'a DataOption> {
+fn get_option<'a>(options: &'a [DataOption], option_name: &'static str) -> Option<&'a DataOption> {
     options.iter().find(|option| option.name == option_name)
 }
 

--- a/src/slash_commands/utils.rs
+++ b/src/slash_commands/utils.rs
@@ -6,14 +6,14 @@ use serenity::model::interactions::application_command::{
 use serenity::model::user::User;
 
 fn get_option<'a>(
-    options: &'a Vec<DataOption>,
+    options: &'a [DataOption],
     option_name: &'static str,
 ) -> Option<&'a DataOption> {
     options.iter().find(|option| option.name == option_name)
 }
 
 pub fn get_string_option<'a>(
-    options: &'a Vec<DataOption>,
+    options: &'a [DataOption],
     option_name: &'static str,
 ) -> Option<&'a str> {
     if let Some(option) = get_option(options, option_name) {
@@ -25,7 +25,7 @@ pub fn get_string_option<'a>(
 }
 
 pub fn get_user_option<'a>(
-    options: &'a Vec<DataOption>,
+    options: &'a [DataOption],
     option_name: &'static str,
 ) -> Option<(&'a User, &'a Option<PartialMember>)> {
     if let Some(option) = get_option(options, option_name) {


### PR DESCRIPTION
Mostly just the invocation of `cargo clippy --fix`, with additional manual touches for borrowed `Box<...>` part.