### PR TITLE
ci: run Rust worflow once on push to master and on PR to master

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,8 +12,6 @@ on:
     branches: [ master ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
-  pull_request:
-    branches: [ master ]
 
 env:
   # Use docker.io for Docker Hub if empty

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust CI
 
 on:
   push:
-    branches: [ '**' ]
+    branches: [ 'master' ]
   pull_request:
-    branches: [ '**' ]
+    branches: [ 'master' ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
There seem to be some issues with duplicate clippy steps? I'm not sure.