### PR TITLE
fix: loosen equality between ranking versions

### DIFF
--- a/src/ranking_watcher/notifier.rs
+++ b/src/ranking_watcher/notifier.rs
@@ -33,22 +33,12 @@ impl ChannelMessageNotifier {
         }
     }
 
-    fn position_changed(p: &PositionChangeInfo) -> bool {
-        match *p {
-            PositionChangeInfo::Diff(x) if x != 0 => true,
-            PositionChangeInfo::New => true,
-            _ => false,
-        }
-    }
-
     fn build_message(&self, ranking: &Ranking) -> String {
         let mut base = self.message.clone();
         let ppl = ranking
-            .iter()
-            .filter(|entry| {
-                Self::position_changed(&entry.pos_diff)
-                    || Self::position_changed(&entry.points_diff)
-            })
+            .get_changed()
+            .0
+            .into_iter()
             .map(|e| {
                 format!(
                     "• {}{} / {} / {}{} pkt",


### PR DESCRIPTION
Now we only compare data that is actually presented in the message.

https://trello.com/c/A8SxZKBO