### PR TITLE
build: bump dependencies

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -41,7 +41,7 @@ jobs:
 
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+        uses: docker/setup-buildx-action@11e8a2e2910826a92412015c515187a2d6750279
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
@@ -57,7 +57,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@507c2f2dc502c992ad446e3d7a5dfbe311567a96
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
@@ -65,7 +65,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,9 +37,9 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "async-trait"
-version = "0.1.60"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d1d8ab452a3936018a687b20e6f7cf5363d713b732b8884001317b0e48aa3"
+checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -73,6 +73,12 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bitflags"
@@ -487,6 +493,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,6 +524,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1385,11 +1403,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
+checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
 dependencies = [
- "base64",
+ "base64 0.21.0",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1422,6 +1440,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
  "winreg",
@@ -1519,7 +1538,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7522c9de787ff061458fe9a829dc790a3f5b22dc571694fc5883f448b94d9a9"
 dependencies = [
- "base64",
+ "base64 0.13.0",
 ]
 
 [[package]]
@@ -1705,7 +1724,7 @@ checksum = "82fd5e7b5858ad96e99d440138f34f5b98e1b959ebcd3a1036203b30e78eb788"
 dependencies = [
  "async-trait",
  "async-tungstenite",
- "base64",
+ "base64 0.13.0",
  "bitflags",
  "bytes",
  "cfg-if",
@@ -1964,9 +1983,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.23.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
+checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2083,7 +2102,7 @@ version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d96a2dea40e7570482f28eb57afbe42d97551905da6a9400acc5c328d24004f5"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "byteorder",
  "bytes",
  "http",
@@ -2201,7 +2220,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a261d60a7215fa339482047cc3dafd4e22e2bf34396aaebef2b707355bbb39c0"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "data-url",
  "flate2",
  "float-cmp",
@@ -2333,6 +2352,19 @@ name = "wasm-bindgen-shared"
 version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
+
+[[package]]
+name = "wasm-streams"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bbae3363c08332cadccd13b67db371814cd214c2524020932f0804b8cf7c078"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "chombot"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-async-trait = "0.1.60"
+async-trait = "0.1.64"
 chrono = { version = "0.4.23", features = ["serde"] }
 image = { version = "0.24.5", default-features = false, features = ["png"] }
-reqwest = "0.11.13"
+reqwest = "0.11.14"
 riichi_hand = "0.2.0"
 scraper = "0.14.0"
 selectors = "0.22.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"
 serenity = { version = "0.11.5", default-features = false, features = ["client", "gateway", "rustls_backend", "model", "unstable_discord_api"] }
-tokio = { version = "1.23.0", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.25.0", features = ["macros", "rt-multi-thread"] }
 slug = "0.1.4"
 
 [profile.release]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.66.0 as builder
+FROM rust:1.67.0 as builder
 
 RUN USER=root cargo new --bin chombot
 

--- a/src/boardowa/mod.rs
+++ b/src/boardowa/mod.rs
@@ -1,6 +1,7 @@
+use std::error::Error;
+
 use chrono::NaiveDate;
 use reqwest::Client;
-use std::error::Error;
 
 pub mod models;
 
@@ -31,7 +32,7 @@ pub async fn get_tables_info(
         .get(API_TABLES_URL)
         .query(&[
             ("date", at.format(DATE_FORMAT).to_string()),
-            ("time", format!("{}-{}", from, to)),
+            ("time", format!("{from}-{to}")),
         ])
         .send()
         .await?

--- a/src/boardowa/models.rs
+++ b/src/boardowa/models.rs
@@ -1,8 +1,9 @@
+use std::error::Error;
+use std::fmt::Display;
+
 use serde::de::Error as SerdeError;
 use serde::de::{Unexpected, Visitor};
 use serde::{Deserialize, Deserializer};
-use std::error::Error;
-use std::fmt::Display;
 
 #[derive(Debug, Deserialize)]
 pub struct TableInfo {

--- a/src/chombot.rs
+++ b/src/chombot.rs
@@ -36,8 +36,8 @@ impl From<HandParseError> for ChombotError {
 impl Display for ChombotError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            ChombotError::Kcc3ClientError(e) => write!(f, "KCC3 client error: {}", e),
-            ChombotError::HandParserError(e) => write!(f, "Hand parse error: {}", e),
+            ChombotError::Kcc3ClientError(e) => write!(f, "KCC3 client error: {e}"),
+            ChombotError::HandParserError(e) => write!(f, "Hand parse error: {e}"),
         }
     }
 }

--- a/src/kcc3/mod.rs
+++ b/src/kcc3/mod.rs
@@ -54,7 +54,7 @@ impl Kcc3Client {
         let mut headers = HeaderMap::new();
         headers.insert(
             "Authorization",
-            HeaderValue::from_str(&format!("Token {}", auth_token))
+            HeaderValue::from_str(&format!("Token {auth_token}"))
                 .expect("Invalid auth token value"),
         );
         let client = reqwest::ClientBuilder::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,6 +127,6 @@ async fn main() {
         .expect("Error creating client");
 
     if let Err(why) = client.start().await {
-        println!("Client error: {:?}", why);
+        println!("Client error: {why:?}");
     }
 }

--- a/src/ranking_watcher/mod.rs
+++ b/src/ranking_watcher/mod.rs
@@ -48,7 +48,7 @@ where
         match (self.get_next)().await {
             Ok(r) => Some(r),
             Err(e) => {
-                println!("Error when fetching ranking: {:?}", e);
+                println!("Error when fetching ranking: {e:?}");
                 None
             }
         }

--- a/src/ranking_watcher/notifier.rs
+++ b/src/ranking_watcher/notifier.rs
@@ -25,8 +25,8 @@ impl ChannelMessageNotifier {
     fn format_delta(p: &PositionChangeInfo) -> String {
         match *p {
             PositionChangeInfo::Diff(delta) => match delta {
-                d if d < 0 => format!("({})", d),
-                d if d > 0 => format!("(+{})", d),
+                d if d < 0 => format!("({d})"),
+                d if d > 0 => format!("(+{d})"),
                 _ => String::from(""),
             },
             PositionChangeInfo::New => String::from("(NEW)"),

--- a/src/ranking_watcher/usma.rs
+++ b/src/ranking_watcher/usma.rs
@@ -147,7 +147,7 @@ fn parse_diff_column(diff_column: &ElementRef) -> Result<PositionChangeInfo> {
                 Ok(PositionChangeInfo::New)
             } else {
                 Err(Box::new(ParseError {
-                    message: format!("Unexpected element without expected classes: {:?}", element),
+                    message: format!("Unexpected element without expected classes: {element:?}"),
                 }))
             }
         }
@@ -192,10 +192,7 @@ async fn get_ranking_impl() -> Result<Ranking> {
     let body = reqwest::get(RANKING_URL).await?.text().await?;
     let html = Html::parse_document(body.as_str());
     let table = select_one!("table tbody", html)?;
-    let entries: Result<Vec<RankingEntry>> = select_all!("tr", table)
-        .into_iter()
-        .map(parse_row)
-        .collect();
+    let entries: Result<Vec<RankingEntry>> = select_all!("tr", table).map(parse_row).collect();
     Ok(Ranking(entries?))
 }
 

--- a/src/slash_commands/boardowa.rs
+++ b/src/slash_commands/boardowa.rs
@@ -51,7 +51,7 @@ impl SlashCommand for BoardowaCommand {
             .create_option(|option| {
                 option
                     .name(DAY_OPTION)
-                    .description("Day of month you want to know about. ")
+                    .description("Day of month you want to know about.")
                     .kind(CommandOptionType::Integer)
                     .min_int_value(1)
                     .max_int_value(31)
@@ -89,8 +89,8 @@ impl SlashCommand for BoardowaCommand {
                 get_tables_info(
                     &client,
                     day_adjusted,
-                    format!("{:02}:01", t),
-                    format!("{:02}:30", t),
+                    format!("{t:02}:01"),
+                    format!("{t:02}:30"),
                 )
                 .await?,
             );
@@ -98,7 +98,7 @@ impl SlashCommand for BoardowaCommand {
                 get_tables_info(
                     &client,
                     day_adjusted,
-                    format!("{:02}:31", t),
+                    format!("{t:02}:31"),
                     format!("{:02}:00", t + 1),
                 )
                 .await?,
@@ -110,7 +110,7 @@ impl SlashCommand for BoardowaCommand {
         let format_time = |idx| {
             let hour: usize = idx / 2 + (opening.from as usize);
             let minutes = if idx % 2 == 0 { 0 } else { 30 };
-            format!("{:02}:{:02}", hour, minutes)
+            format!("{hour:02}:{minutes:02}")
         };
 
         let mut message = format!(

--- a/src/slash_commands/hand.rs
+++ b/src/slash_commands/hand.rs
@@ -72,7 +72,7 @@ impl SlashCommand for HandCommand {
             YELLOW_TILE_SET => Ok(TileStyle::Yellow),
             RED_TILE_SET => Ok(TileStyle::Red),
             BLACK_TILE_SET => Ok(TileStyle::Black),
-            _ => Err(format!("Invalid tile set: {}", tile_set)),
+            _ => Err(format!("Invalid tile set: {tile_set}")),
         }?;
 
         let image = chombot.render_hand(hand, render_tile_set).await?;

--- a/src/slash_commands/mod.rs
+++ b/src/slash_commands/mod.rs
@@ -78,7 +78,7 @@ impl SlashCommands {
             .await;
 
         if let Err(err) = error_response_result {
-            println!("Could not set error response: {:?}", err);
+            println!("Could not set error response: {err:?}");
         }
     }
 
@@ -90,11 +90,8 @@ impl SlashCommands {
         requested_command_name: &str,
     ) -> Result<(), String> {
         if let Err(e) = slash_command.handle(ctx, command, chombot).await {
-            println!(
-                "Handler error for command {}: {:?}",
-                requested_command_name, e
-            );
-            Err(format!("Could not generate response:\n```\n{}\n```", e))
+            println!("Handler error for command {requested_command_name}: {e:?}");
+            Err(format!("Could not generate response:\n```\n{e}\n```"))
         } else {
             Ok(())
         }
@@ -108,7 +105,7 @@ impl SlashCommands {
                 })
                 .await;
             if let Err(e) = deferred_result {
-                println!("Could not create deferred response: {:?}", e);
+                println!("Could not create deferred response: {e:?}");
                 return;
             }
 
@@ -127,7 +124,7 @@ impl SlashCommands {
                     Self::set_error_message(&ctx, &command, msg.as_str()).await;
                 }
             } else {
-                println!("Invalid command received: {}", requested_command_name);
+                println!("Invalid command received: {requested_command_name}");
             }
         }
     }

--- a/src/slash_commands/pasta/command.rs
+++ b/src/slash_commands/pasta/command.rs
@@ -63,7 +63,7 @@ impl SlashCommand for PastaCommand {
             JGAMESCON_PASTA_OPTION => Ok(JGAMESCON_PASTA),
             TANJALO_PASTA_OPTION => Ok(TANJALO_PASTA),
             STOWARZYSZENIE_PASTA_OPTION => Ok(STOWARZYSZENIE_PASTA),
-            _ => Err(format!("Invalid pasta: {}", pasta_option)),
+            _ => Err(format!("Invalid pasta: {pasta_option}")),
         }?;
         let pasta_content = format!("{}\n||#pasta||", pasta.trim());
 


### PR DESCRIPTION
Also apply suggestions from clippy (mostly inlining variables in `format!`). Contains all current Dependabot suggestions. Also bump edition to 2021.