### PR TITLE
Cache grcov in Github workflow 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -93,7 +93,9 @@ jobs:
           RUSTFLAGS: '-Cinstrument-coverage'
 
       - name: Install grcov
-        run: if [[ ! -e ~/.cargo/bin/grcov ]]; then cargo install grcov; fi
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: grcov
 
       - name: Run grcov
         run: grcov . --binary-path target/debug/deps/ -s . -t lcov --branch --ignore-not-existing --ignore '../**' --ignore '/*' -o coverage.lcov

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,10 @@ repos:
   - id: fmt
   - id: clippy
   - id: cargo-check
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.4.0
+  hooks:
+  - id: check-yaml
+  - id: check-toml
+  - id: trailing-whitespace
+  - id: end-of-file-fixer


### PR DESCRIPTION
As can be seen in https://github.com/riichi/chombot/actions/caches, a new cache for grcov was introduced by an action in this PR.