### PR TITLE
chore: enable pedantic/nursery Clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,11 @@
 name = "chombot"
 version = "0.1.0"
 edition = "2021"
+license-file = "LICENSE"
+description = "Discord bot for Riichi Mahjong servers."
+repository = "https://github.com/riichi/chombot"
+keywords = ["riichi", "mahjong", "discord", "chombo"]
+categories = ["multimedia::images"]
 
 [dependencies]
 anyhow = "1.0.75"

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::struct_excessive_bools)]
+
 use clap::Parser;
 
 #[derive(Parser)]

--- a/src/chombot.rs
+++ b/src/chombot.rs
@@ -78,7 +78,7 @@ pub struct Chombot {
 }
 
 impl Chombot {
-    pub fn new(kcc3client: Option<Kcc3Client>) -> Self {
+    pub const fn new(kcc3client: Option<Kcc3Client>) -> Self {
         Self { kcc3client }
     }
 
@@ -95,8 +95,8 @@ impl Chombot {
         comment: &str,
     ) -> ChombotResult<Chombo>
     where
-        P: Fn(&Player) -> bool,
-        F: Fn() -> Player,
+        P: (Fn(&Player) -> bool) + Send + Sync,
+        F: (Fn() -> Player) + Send + Sync,
     {
         let client = self.get_client()?;
         let players = client.get_players().await?;
@@ -152,7 +152,7 @@ impl Chombot {
         Ok(chombos)
     }
 
-    pub async fn render_hand(&self, hand: &str, tile_style: TileStyle) -> ChombotResult<RgbaImage> {
+    pub fn render_hand(hand: &str, tile_style: &TileStyle) -> ChombotResult<RgbaImage> {
         let tile_set: Box<dyn TileSet> = match tile_style {
             TileStyle::Yellow => Box::new(&*YELLOW_FLUFFY_STUFF_TILE_SET),
             TileStyle::Red => Box::new(&*RED_FLUFFY_STUFF_TILE_SET),

--- a/src/data_watcher.rs
+++ b/src/data_watcher.rs
@@ -40,9 +40,9 @@ pub struct DataWatcher<T, F, H> {
 impl<T, F, H, HOut, E> DataWatcher<T, F, H>
 where
     T: Eq + Send + Sync,
-    F: DataUpdateNotifier<T>,
-    H: Fn() -> HOut,
-    HOut: Future<Output = Result<T, E>>,
+    F: DataUpdateNotifier<T> + Send + Sync,
+    H: (Fn() -> HOut) + Send + Sync,
+    HOut: Future<Output = Result<T, E>> + Send + Sync,
     E: Debug,
 {
     #[must_use]
@@ -57,7 +57,7 @@ where
     }
 
     #[must_use]
-    pub fn new(update_notifier: F, get_next: H) -> Self {
+    pub const fn new(update_notifier: F, get_next: H) -> Self {
         Self {
             previous_data: None,
             update_notifier,

--- a/src/kcc3/data_types.rs
+++ b/src/kcc3/data_types.rs
@@ -31,18 +31,18 @@ impl Player {
     pub fn new_from_discord(id: PlayerId, nickname: String, discord_id: DiscordId) -> Self {
         Self {
             id,
-            first_name: Default::default(),
-            last_name: Default::default(),
+            first_name: String::default(),
+            last_name: String::default(),
             nickname,
             discord_id,
         }
     }
 
     pub fn short_name(&self) -> String {
-        if !self.nickname.is_empty() {
-            self.nickname.clone()
-        } else {
+        if self.nickname.is_empty() {
             format!("{} {}", self.first_name, self.last_name)
+        } else {
+            self.nickname.clone()
         }
     }
 }
@@ -87,7 +87,7 @@ mod tests {
             id: Default::default(),
             first_name: "A".to_string(),
             last_name: "B".to_string(),
-            nickname: "".to_string(),
+            nickname: String::new(),
             discord_id: Default::default(),
         };
         assert_eq!(player.short_name(), "A B");

--- a/src/kcc3/mod.rs
+++ b/src/kcc3/mod.rs
@@ -25,7 +25,7 @@ impl Error for Kcc3ClientError {
 }
 
 impl Kcc3ClientError {
-    fn new(inner_error: reqwest::Error) -> Self {
+    const fn new(inner_error: reqwest::Error) -> Self {
         Self { inner_error }
     }
 }
@@ -88,10 +88,10 @@ impl Kcc3Client {
             .error_for_status()?
             .json()
             .await
-            .map_err(|x| x.into())
+            .map_err(std::convert::Into::into)
     }
 
-    async fn api_call_post<T: DeserializeOwned, P: Serialize>(
+    async fn api_call_post<T: DeserializeOwned, P: Serialize + Sync + Send>(
         &self,
         endpoint: &str,
         payload: P,
@@ -103,6 +103,6 @@ impl Kcc3Client {
             .error_for_status()?
             .json()
             .await
-            .map_err(|x| x.into())
+            .map_err(std::convert::Into::into)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,8 @@
+#![warn(clippy::pedantic)]
+#![warn(clippy::nursery)]
+#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::unreadable_literal)]
+
 use anyhow::Error;
 use clap::Parser;
 use log::{error, info, LevelFilter};
@@ -37,7 +42,7 @@ pub struct PoiseUserData {
 
 pub type PoiseContext<'a> = Context<'a, PoiseUserData, anyhow::Error>;
 
-async fn start_ranking_watcher(args: &Arguments, ctx: SerenityContext) {
+fn start_ranking_watcher(args: &Arguments, ctx: SerenityContext) {
     if !args.feature_ranking_watcher {
         return;
     }
@@ -53,7 +58,10 @@ async fn start_ranking_watcher(args: &Arguments, ctx: SerenityContext) {
     });
 }
 
-async fn start_tournaments_watcher(args: &Arguments, ctx: SerenityContext) {
+fn start_tournaments_watcher(args: &Arguments, ctx: SerenityContext) {
+    const MESSAGE_PREFIX: &str =
+        "**TOURNAMENTS UPDATE** (http://mahjong-europe.org/ranking/Calendar.html)\n\n";
+
     if !args.feature_tournaments_watcher {
         return;
     }
@@ -61,8 +69,6 @@ async fn start_tournaments_watcher(args: &Arguments, ctx: SerenityContext) {
         .tournaments_watcher_channel_id
         .expect("Tournaments watcher feature enabled but no channel ID provided");
 
-    const MESSAGE_PREFIX: &str =
-        "**TOURNAMENTS UPDATE** (http://mahjong-europe.org/ranking/Calendar.html)\n\n";
     let notifier = TournamentsChannelMessageNotifier::new(
         ChannelId(tournaments_watcher_channel_id),
         String::from(MESSAGE_PREFIX),
@@ -153,8 +159,8 @@ async fn main() {
         .intents(GatewayIntents::non_privileged())
         .setup(|ctx, ready, framework| {
             Box::pin(async move {
-                start_ranking_watcher(&args, ctx.clone()).await;
-                start_tournaments_watcher(&args, ctx.clone()).await;
+                start_ranking_watcher(&args, ctx.clone());
+                start_tournaments_watcher(&args, ctx.clone());
                 poise::builtins::register_globally(ctx, &framework.options().commands).await?;
                 info!("{} is connected!", ready.user.name);
                 Ok(PoiseUserData { chombot })

--- a/src/ranking_watcher/notifier.rs
+++ b/src/ranking_watcher/notifier.rs
@@ -12,7 +12,7 @@ pub struct ChannelMessageNotifier {
 }
 
 impl ChannelMessageNotifier {
-    pub fn new(channel_id: ChannelId, message: String) -> Self {
+    pub const fn new(channel_id: ChannelId, message: String) -> Self {
         Self {
             channel_id,
             message,
@@ -24,7 +24,7 @@ impl ChannelMessageNotifier {
             PositionChangeInfo::Diff(delta) => match delta {
                 d if d < 0 => format!(" (↓{})", -d),
                 d if d > 0 => format!(" (↑{d})"),
-                _ => String::from(""),
+                _ => String::new(),
             },
             PositionChangeInfo::New => String::from(" (NEW)"),
         }
@@ -34,7 +34,7 @@ impl ChannelMessageNotifier {
         match *p {
             PositionChangeInfo::Diff(d) if d < 0 => format!(" ({d})"),
             PositionChangeInfo::Diff(d) if d > 0 => format!(" (+{d})"),
-            _ => String::from(""),
+            _ => String::new(),
         }
     }
 
@@ -123,6 +123,6 @@ mod tests {
                 "• 5 (NEW) / player-name-003 / 1830 (-60) pkt\n",
                 "• 8 (↓3) / player-name-004 / 1718 (+73) pkt"
             )
-        )
+        );
     }
 }

--- a/src/ranking_watcher/usma.rs
+++ b/src/ranking_watcher/usma.rs
@@ -16,8 +16,8 @@ pub enum PositionChangeInfo {
 }
 
 impl PositionChangeInfo {
-    pub fn has_changed(&self) -> bool {
-        !matches!(self, PositionChangeInfo::Diff(0))
+    pub const fn has_changed(&self) -> bool {
+        !matches!(self, Self::Diff(0))
     }
 }
 
@@ -31,7 +31,7 @@ pub struct RankingEntry {
 }
 
 impl RankingEntry {
-    pub fn has_changed(&self) -> bool {
+    pub const fn has_changed(&self) -> bool {
         self.points_diff.has_changed() || self.pos_diff.has_changed()
     }
 }

--- a/src/scraping_utils.rs
+++ b/src/scraping_utils.rs
@@ -36,16 +36,16 @@ macro_rules! select_one {
 
 pub(crate) use {select_all, select_one, unpack_children};
 
-pub(crate) fn first_nonempty_text<'a>(e: &'a ElementRef) -> anyhow::Result<&'a str> {
+pub fn first_nonempty_text<'a>(e: &'a ElementRef) -> anyhow::Result<&'a str> {
     let ret = e
         .text()
         .map(str::trim)
         .find(|s| !s.is_empty())
-        .ok_or(anyhow!("No non-empty text nodes found"))?;
+        .ok_or_else(|| anyhow!("No non-empty text nodes found"))?;
     Ok(ret)
 }
 
 #[must_use]
-pub(crate) fn cell_text(e: &ElementRef) -> String {
-    e.text().map(|s| s.trim()).join(" ").trim().to_owned()
+pub fn cell_text(e: &ElementRef) -> String {
+    e.text().map(str::trim).join(" ").trim().to_owned()
 }

--- a/src/slash_commands/chombo.rs
+++ b/src/slash_commands/chombo.rs
@@ -7,6 +7,7 @@ use crate::{Chombo, Chombot, DiscordId, Player, PlayerId, PoiseContext};
 
 #[poise::command(slash_command, subcommands("ranking", "list", "add"))]
 pub async fn chombo(_: PoiseContext<'_>) -> Result<()> {
+    #![allow(clippy::unused_async)]
     Ok(())
 }
 
@@ -74,8 +75,8 @@ async fn add(
 async fn get_chombos_embed_entries(
     chombot: &Chombot,
 ) -> Result<impl Iterator<Item = (String, usize, bool)>> {
-    let chombos = chombot.create_chombo_ranking().await?;
-    Ok(chombos
+    let chombo_ranking = chombot.create_chombo_ranking().await?;
+    Ok(chombo_ranking
         .into_iter()
         .map(|(player, num)| (player.short_name(), num, true)))
 }
@@ -96,9 +97,9 @@ fn format_add_message(user: &User, description: &str) -> String {
 }
 
 async fn create_chombos_list(chombot: &Chombot) -> Result<String> {
-    let chombos = chombot.get_chombo_list().await?;
+    let chombo_list = chombot.get_chombo_list().await?;
     let mut result = String::new();
-    for (player, chombo) in &chombos {
+    for (player, chombo) in &chombo_list {
         let entry = format_chombo_entry(player, chombo);
         if result.len() + entry.len() <= DISCORD_MESSAGE_SIZE_LIMIT {
             result += &entry;
@@ -112,7 +113,7 @@ async fn create_chombos_list(chombot: &Chombot) -> Result<String> {
 
 fn format_chombo_entry(player: &Player, chombo: &Chombo) -> String {
     let comment = if chombo.comment.is_empty() {
-        "".to_owned()
+        String::new()
     } else {
         format!(": *{}*", chombo.comment)
     };

--- a/src/slash_commands/hand.rs
+++ b/src/slash_commands/hand.rs
@@ -5,7 +5,7 @@ use image::DynamicImage;
 use poise::serenity_prelude::{AttachmentType, CacheHttp};
 use poise::ChoiceParameter;
 
-use crate::chombot::TileStyle;
+use crate::chombot::{Chombot, TileStyle};
 use crate::PoiseContext;
 
 #[derive(Debug, ChoiceParameter)]
@@ -44,9 +44,8 @@ pub async fn hand(
     #[description = "Tile style"] tileset: Option<Tileset>,
 ) -> Result<()> {
     let tile_style: TileStyle = tileset.unwrap_or_default().into();
-    let chombot = &ctx.data().chombot;
 
-    let image = chombot.render_hand(&hand, tile_style).await?;
+    let image = Chombot::render_hand(&hand, &tile_style)?;
     let mut buf = Vec::new();
     DynamicImage::ImageRgba8(image)
         .write_to(&mut Cursor::new(&mut buf), image::ImageOutputFormat::Png)?;

--- a/src/slash_commands/pasta/command.rs
+++ b/src/slash_commands/pasta/command.rs
@@ -20,7 +20,7 @@ pub enum Pasta {
 }
 
 impl Pasta {
-    pub fn content(&self) -> &'static str {
+    pub const fn content(&self) -> &'static str {
         match self {
             Self::JGamesCon => include_str!("jgamescon.txt"),
             Self::Tanjalo => include_str!("tanjalo.txt"),

--- a/src/slash_commands/score.rs
+++ b/src/slash_commands/score.rs
@@ -25,9 +25,9 @@ impl Default for Mode {
 impl From<Mode> for PointsCalculationMode {
     fn from(value: Mode) -> Self {
         match value {
-            Mode::Default => PointsCalculationMode::Default,
-            Mode::Loose => PointsCalculationMode::Loose,
-            Mode::Unlimited => PointsCalculationMode::Unlimited,
+            Mode::Default => Self::Default,
+            Mode::Loose => Self::Loose,
+            Mode::Unlimited => Self::Unlimited,
         }
     }
 }
@@ -56,7 +56,7 @@ pub async fn score(
     let fu = Fu::new(fu);
     let honbas = honbas.map(Honbas::new).unwrap_or_default();
     let points = Points::from_calculated(points_calculation_mode, han, fu, honbas)?;
-    let fields = create_points_embed_fields(points);
+    let fields = create_points_embed_fields(&points);
 
     ctx.send(|reply| reply.embed(move |embed| create_points_embed(embed, han, fu, honbas, fields)))
         .await?;
@@ -78,7 +78,7 @@ fn create_points_embed(
 }
 
 fn create_points_embed_fields(
-    points: Points,
+    points: &Points,
 ) -> impl Iterator<Item = (&'static str, String, bool)> {
     info!("{points:?}");
     [
@@ -95,16 +95,13 @@ fn create_points_embed_fields(
 }
 
 fn format_points(points: Option<BigInt>) -> String {
-    match points {
-        None => "N/A".to_owned(),
-        Some(value) => value.to_string(),
-    }
+    points.map_or_else(|| "N/A".to_owned(), |value| value.to_string())
 }
 
 fn format_ko_tsumo_points(points: Option<(BigInt, BigInt)>) -> String {
     match points {
         None => "N/A".to_owned(),
-        Some((value_ko, value_oya)) => format!("{}/{}", value_ko, value_oya),
+        Some((value_ko, value_oya)) => format!("{value_ko}/{value_oya}"),
     }
 }
 
@@ -119,7 +116,7 @@ mod tests {
             #[test]
             fn $id() {
                 let points: Points = $points;
-                let fields: Vec<_> = create_points_embed_fields(points).collect();
+                let fields: Vec<_> = create_points_embed_fields(&points).collect();
                 assert_eq!(fields, vec![
                     ("Non-dealer tsumo", String::from($ko_tsumo), false),
                     ("Non-dealer ron", String::from($ko_ron), false),

--- a/src/tournaments_watcher/notifier.rs
+++ b/src/tournaments_watcher/notifier.rs
@@ -20,7 +20,7 @@ pub struct TournamentsChannelMessageNotifier {
 
 impl TournamentsChannelMessageNotifier {
     #[must_use]
-    pub fn new(channel_id: ChannelId, message: String) -> Self {
+    pub const fn new(channel_id: ChannelId, message: String) -> Self {
         Self {
             channel_id,
             message,
@@ -66,16 +66,16 @@ fn diff_as_message(diff: &TournamentStatus) -> String {
             str += &format!("**CHANGED**: _{}_; ", change.name);
 
             if let Some(date) = &change.date {
-                str += &format!("date: {}; ", date);
+                str += &format!("date: {date}; ");
             }
             if let Some(place) = &change.place {
-                str += &format!("place: {}; ", place);
+                str += &format!("place: {place}; ");
             }
             if let Some(approval_status) = &change.approval_status {
-                str += &format!("MERS approval: {}; ", approval_status);
+                str += &format!("MERS approval: {approval_status}; ");
             }
             if let Some(results) = &change.results_status {
-                str += &format!("results: \"{}\"; ", results);
+                str += &format!("results: \"{results}\"; ");
             }
 
             if let Some(trimmed) = str.strip_suffix("; ") {
@@ -132,7 +132,7 @@ mod tests {
                 date: "27-31 November 2023".to_owned(),
                 place: "Krakow".to_owned(),
                 approval_status: "OK".to_owned(),
-                results_status: "".to_owned(),
+                results_status: String::new(),
             }),
         ];
 


### PR DESCRIPTION
Also addressed `clippy::cargo` warnings regarding package metadata. `nursery` might be to excessive - lmk if it's ok.
Allowed `module_name_repetitions` (too intrusive imo) and `unreadable_literal` (it gave a false positive).
Also allowed `struct_excessive_bools` in `args` module.