### PR TITLE
feat: use serde for de/serializing GuildId

### DIFF
--- a/chombot/src/config.rs
+++ b/chombot/src/config.rs
@@ -117,6 +117,7 @@ impl<'a> DerefMut for ConfigUpdateGuard<'a> {
 
 #[cfg(test)]
 mod tests {
+    use poise::serenity_prelude::ChannelId;
     use std::collections::HashMap;
 
     use tempfile::NamedTempFile;
@@ -131,15 +132,15 @@ mod tests {
         let config = Config {
             guilds: HashMap::from([
                 (
-                    GuildId::new(69),
+                    GuildId(69),
                     GuildConfig {
-                        tournaments_watcher_channel_id: Some(2137),
+                        tournaments_watcher_channel_id: Some(ChannelId(2137)),
                     },
                 ),
                 (
-                    GuildId::new(420),
+                    GuildId(420),
                     GuildConfig {
-                        tournaments_watcher_channel_id: Some(69),
+                        tournaments_watcher_channel_id: Some(ChannelId(69)),
                     },
                 ),
             ]),

--- a/chombot/src/config.rs
+++ b/chombot/src/config.rs
@@ -117,9 +117,9 @@ impl<'a> DerefMut for ConfigUpdateGuard<'a> {
 
 #[cfg(test)]
 mod tests {
-    use poise::serenity_prelude::ChannelId;
     use std::collections::HashMap;
 
+    use poise::serenity_prelude::ChannelId;
     use tempfile::NamedTempFile;
 
     use crate::config::{ChombotConfig, Config, GuildConfig, GuildId};

--- a/chombot/src/config.rs
+++ b/chombot/src/config.rs
@@ -8,19 +8,8 @@ use std::path::PathBuf;
 use async_trait::async_trait;
 use chombot_common::tournaments_watcher::notifier::TournamentWatcherChannelListProvider;
 use log::info;
-use poise::serenity_prelude::ChannelId;
+use poise::serenity_prelude::{ChannelId, GuildId};
 use serde::{Deserialize, Serialize};
-
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct GuildId(String);
-
-impl GuildId {
-    #[must_use]
-    pub fn new(value: u64) -> Self {
-        Self(value.to_string())
-    }
-}
 
 #[derive(Clone, Default, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Config {
@@ -32,7 +21,7 @@ pub struct Config {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
 pub struct GuildConfig {
     /// Tournaments watcher channel ID
-    pub tournaments_watcher_channel_id: Option<u64>,
+    pub tournaments_watcher_channel_id: Option<ChannelId>,
 }
 
 #[async_trait]
@@ -40,10 +29,11 @@ impl TournamentWatcherChannelListProvider for ChombotConfig {
     type TournamentWatcherChannelList = Vec<ChannelId>;
 
     async fn tournament_watcher_channels(&self) -> Self::TournamentWatcherChannelList {
-        let channel_ids =
-            self.config.guilds.iter().filter_map(|(_, config)| {
-                config.tournaments_watcher_channel_id.map(ChannelId::from)
-            });
+        let channel_ids = self
+            .config
+            .guilds
+            .iter()
+            .filter_map(|(_, config)| config.tournaments_watcher_channel_id);
 
         channel_ids.collect()
     }

--- a/chombot/src/tournament_watcher.rs
+++ b/chombot/src/tournament_watcher.rs
@@ -1,5 +1,5 @@
 use anyhow::anyhow;
-use poise::serenity_prelude::ChannelId;
+use poise::serenity_prelude::{ChannelId, GuildId};
 
 use crate::{config, PoiseContext};
 
@@ -16,9 +16,9 @@ pub async fn tournament_watcher(
         config
             .config_mut()
             .guilds
-            .entry(config::GuildId::new(guild.0))
+            .entry(guild)
             .or_default()
-            .tournaments_watcher_channel_id = channel.map(|x| x.0);
+            .tournaments_watcher_channel_id = channel;
     }
 
     let reply_content = channel.as_ref().map_or_else(


### PR DESCRIPTION
[Serde](https://serde.rs/) is smart and can handle a lot of de/serializing magic. This PR aims to reduce extraneous manual implementations in favor of Serde's existing functionality. 

I know deserializing works in this case (Serde is fully capable of taking a `String` as input and going through multiple transformations of `String -> u64 -> GuildId`); however, I need to do more testing for serializing (some additional Serde magic might be needed to force it to serialize to `String`, nothing though that Serde shouldn't be capable of); therefore, this PR is in draft mode for now.