### PR TITLE
deps: use upstream poise again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1568,8 +1568,9 @@ dependencies = [
 
 [[package]]
 name = "poise"
-version = "0.5.6"
-source = "git+https://github.com/m4tx/poise.git#7c85e3f787211da979b739315266e1ce190e6f42"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d104e4b5847283b2fbd6a7ec19fb6a8af328e2145623d056b66d750a30073fdf"
 dependencies = [
  "async-trait",
  "derivative",
@@ -1586,8 +1587,9 @@ dependencies = [
 
 [[package]]
 name = "poise_macros"
-version = "0.5.6"
-source = "git+https://github.com/m4tx/poise.git#7c85e3f787211da979b739315266e1ce190e6f42"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb516a8cf4e4ae4bd7ef5819d08c6ca408976461a9bea3ee3eec5138ac070c1"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,4 @@ env_logger = "0.10.0"
 log = "0.4.20"
 num-bigint = "0.4.4"
 itertools = "0.11.0"
-poise = { git = "https://github.com/m4tx/poise.git" }
+poise = "0.5.7"


### PR DESCRIPTION
The [0.5.7 poise release](https://github.com/serenity-rs/poise/releases/tag/v0.5.7) includes the generics feature chombot requires. We can revert to using upstream again.