### PR TITLE
fix: report tournament website changes in the tournament watcher

### DIFF
--- a/chombot-common/src/tournaments_watcher/notifier.rs
+++ b/chombot-common/src/tournaments_watcher/notifier.rs
@@ -97,7 +97,7 @@ fn diff_as_message(diff: &TournamentStatus) -> String {
 
             if let Some(url) = &change.url {
                 if !url.is_empty() {
-                    str += &format!("website: {url}");
+                    str += &format!("website: {url}; ");
                 }
             }
             if let Some(date) = &change.date {
@@ -180,7 +180,7 @@ mod tests {
                 rules: None,
                 date: None,
                 place: None,
-                approval_status: None,
+                approval_status: Some("OK".to_owned()),
                 results_status: None,
             }),
             TournamentStatus::Changed(TournamentChange {

--- a/chombot-common/src/tournaments_watcher/notifier.rs
+++ b/chombot-common/src/tournaments_watcher/notifier.rs
@@ -80,8 +80,7 @@ fn diff_as_message(diff: &TournamentStatus) -> String {
 
     match diff {
         TournamentStatus::New(entry) => {
-            str += "**NEW**: ";
-            str += &format!("_{}_", entry.name);
+            str += &format!("**NEW**: _{}_", entry.name);
             if !entry.url.is_empty() {
                 str += &format!(" ({})", entry.url);
             }
@@ -96,6 +95,11 @@ fn diff_as_message(diff: &TournamentStatus) -> String {
         TournamentStatus::Changed(change) => {
             str += &format!("**CHANGED**: _{}_; ", change.name);
 
+            if let Some(url) = &change.url {
+                if !url.is_empty() {
+                    str += &format!("website: {url}");
+                }
+            }
             if let Some(date) = &change.date {
                 str += &format!("date: {date}; ");
             }
@@ -169,6 +173,24 @@ mod tests {
                 place: "Krakow".to_owned(),
                 approval_status: "OK".to_owned(),
                 results_status: String::new(),
+            }),
+            TournamentStatus::Changed(TournamentChange {
+                name: "ERMC 2024".to_owned(),
+                url: Some("abc.com".to_owned()),
+                rules: None,
+                date: None,
+                place: None,
+                approval_status: None,
+                results_status: None,
+            }),
+            TournamentStatus::Changed(TournamentChange {
+                name: "ERMC 2025".to_owned(),
+                url: Some("".to_owned()),
+                rules: None,
+                date: None,
+                place: None,
+                approval_status: None,
+                results_status: None,
             }),
         ];
 

--- a/chombot-common/src/tournaments_watcher/test_data/expected_message.txt
+++ b/chombot-common/src/tournaments_watcher/test_data/expected_message.txt
@@ -1,4 +1,4 @@
 * **CHANGED**: _Poteto Riichi Taikai 2023_; date: 1-2 November 2023; results: "Results"
 * **NEW**: _Krakow Riichi Open_ (https://chombo.club); 27-31 November 2023; Krakow; MERS: OK
-* **CHANGED**: _ERMC 2024_; website: abc.com
+* **CHANGED**: _ERMC 2024_; website: abc.com; MERS approval: OK
 * **CHANGED**: _ERMC 2025_

--- a/chombot-common/src/tournaments_watcher/test_data/expected_message.txt
+++ b/chombot-common/src/tournaments_watcher/test_data/expected_message.txt
@@ -1,2 +1,4 @@
 * **CHANGED**: _Poteto Riichi Taikai 2023_; date: 1-2 November 2023; results: "Results"
 * **NEW**: _Krakow Riichi Open_ (https://chombo.club); 27-31 November 2023; Krakow; MERS: OK
+* **CHANGED**: _ERMC 2024_; website: abc.com
+* **CHANGED**: _ERMC 2025_


### PR DESCRIPTION
Not sure what to do with changes to `""` though, skipped them for now.